### PR TITLE
Fix: local filepath retrieval based on relation to config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ $(BINDIR)/$(BINNAME): $(SRC)
 	CGO_ENABLED=$(CGO_ENABLED) go build $(GOFLAGS) -trimpath -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o '$(BINDIR)/$(BINNAME)' .
 
 .PHONY: generate-file
-generate-file: ## Generate an aggregate component-definition.yaml file
-	./bin/component-generator aggregate -i testdata/input/components.yaml
+generate-file: build ## Generate an aggregate component-definition.yaml file
+	./bin/component-generator aggregate -i testdata/input/valid-components.yaml
 
 .PHONY: generate-stdout
 generate-stdout: ## Generate aggregate file to stdout

--- a/src/cmd/aggregate.go
+++ b/src/cmd/aggregate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/defenseunicorns/component-generator/src/internal/types"
@@ -96,6 +97,7 @@ func run() {
 
 	} else {
 		_, err := os.Stat(path)
+
 		if os.IsNotExist(err) {
 			fmt.Printf("Path: %v does not exist - unable to digest document\n", path)
 		}
@@ -110,6 +112,8 @@ func run() {
 			log.Fatal(err)
 		}
 	}
+
+	config.BaseDirectory, _ = filepath.Split(path)
 
 	yamlDoc, oscalObj, err := component.BuildOscalDocument(config)
 	if err != nil {

--- a/src/internal/types/component.go
+++ b/src/internal/types/component.go
@@ -1,9 +1,10 @@
 package types
 
 type ComponentsConfig struct {
-	Name       string    `json:"name" yaml:"name"`
-	Metadata   Metadata  `json:"metadata" yaml:"metadata"`
-	Components Component `json:"components" yaml:"components"`
+	Name          string    `json:"name" yaml:"name"`
+	Metadata      Metadata  `json:"metadata" yaml:"metadata"`
+	Components    Component `json:"components" yaml:"components"`
+	BaseDirectory string    `json:"base-directory" yaml:"base-directory"`
 }
 
 type Component struct {

--- a/src/pkg/component/component.go
+++ b/src/pkg/component/component.go
@@ -21,7 +21,7 @@ func BuildOscalDocument(config types.ComponentsConfig) (string, types.OscalCompo
 	)
 
 	for _, local := range config.Components.Locals {
-		document, err := oscal.GetOscalComponentFromLocal(local.Name)
+		document, err := oscal.GetOscalComponentFromLocal(config.BaseDirectory + local.Name)
 		if err != nil {
 			return "", types.OscalComponentDocument{}, err
 		}

--- a/src/pkg/component/component_test.go
+++ b/src/pkg/component/component_test.go
@@ -3,6 +3,7 @@ package component
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/defenseunicorns/component-generator/src/internal/types"
@@ -184,6 +185,8 @@ func readConfigFile(t *testing.T, filePath string) (configFile types.ComponentsC
 	if err = yaml.Unmarshal(configBytes, &configFile); err != nil {
 		return configFile, fmt.Errorf("failed to unmarshal config file data: %v", err)
 	}
+
+	configFile.BaseDirectory, _ = filepath.Split(filePath)
 
 	return configFile, nil
 }

--- a/testdata/input/invalid-components.yaml
+++ b/testdata/input/invalid-components.yaml
@@ -12,7 +12,7 @@ metadata:
       type: organization
 components:
     local:
-    - name: ../../../testdata/input/jaeger-component-definition.yaml
+    - name: jaeger-component-definition.yaml
 
     remote:
     - git: https://github.com/defenseunicorns/terraform-aws-uds-s3 # leaving off '@<git ref>'' should produce an error

--- a/testdata/input/valid-components.yaml
+++ b/testdata/input/valid-components.yaml
@@ -12,7 +12,7 @@ metadata:
       type: organization
 components:
     local:
-    - name: ../../../testdata/input/jaeger-component-definition.yaml
+    - name: jaeger-component-definition.yaml
 
     remote:
     - git: https://github.com/defenseunicorns/terraform-aws-uds-s3@v0.0.3


### PR DESCRIPTION
Fixes #22 

The path to a local file should be in-relation to the configuration file (in my opinion - as this is what makes it declarative).

@CloudBeard Do we have the local block used anywhere currently? this may break that depending on how it is executed.